### PR TITLE
Feature/add not on loan attribute to item

### DIFF
--- a/nlbsg/_factories.py
+++ b/nlbsg/_factories.py
@@ -77,7 +77,7 @@ def get_availability_info_response_factory(response):
                 category_name=item['CategoryName'],
                 collection_code=item['CollectionCode'],
                 collection_min_age_limit=item['CollectionMinAgeLimit'],
-                not_on_loan=item['StatusDesc'] == "Not On Loan"
+                available=item['StatusDesc'] == "Not On Loan"
             ))
     except TypeError:
         items = None

--- a/nlbsg/_factories.py
+++ b/nlbsg/_factories.py
@@ -77,6 +77,7 @@ def get_availability_info_response_factory(response):
                 category_name=item['CategoryName'],
                 collection_code=item['CollectionCode'],
                 collection_min_age_limit=item['CollectionMinAgeLimit'],
+                not_on_loan=True if item['StatusDesc'] == "Not On Loan" else False,
             ))
     except TypeError:
         items = None

--- a/nlbsg/_factories.py
+++ b/nlbsg/_factories.py
@@ -77,7 +77,7 @@ def get_availability_info_response_factory(response):
                 category_name=item['CategoryName'],
                 collection_code=item['CollectionCode'],
                 collection_min_age_limit=item['CollectionMinAgeLimit'],
-                not_on_loan=True if item['StatusDesc'] == "Not On Loan" else False,
+                not_on_loan=item['StatusDesc'] == "Not On Loan"
             ))
     except TypeError:
         items = None

--- a/nlbsg/types.py
+++ b/nlbsg/types.py
@@ -217,6 +217,7 @@ Part of `GetAvailabilityInfoResponse`.
 :var Optional[str] category_name:
 :var Optional[str] collection_code:
 :var Optional[str] collection_min_age_limit:
+:var bool not_on_loan:
 
 Example `Item`::
 
@@ -236,7 +237,8 @@ Example `Item`::
         cluster_name=None,
         category_name=None,
         collection_code=None,
-        collection_min_age_limit=None
+        collection_min_age_limit=None,
+        not_on_loan=False,
     )
 
     """

--- a/nlbsg/types.py
+++ b/nlbsg/types.py
@@ -256,6 +256,7 @@ Example `Item`::
     category_name: Optional[str]
     collection_code: Optional[str]
     collection_min_age_limit: Optional[str]
+    not_on_loan: bool
 
 
 @dataclass

--- a/nlbsg/types.py
+++ b/nlbsg/types.py
@@ -217,7 +217,7 @@ Part of `GetAvailabilityInfoResponse`.
 :var Optional[str] category_name:
 :var Optional[str] collection_code:
 :var Optional[str] collection_min_age_limit:
-:var bool not_on_loan:
+:var bool available:
 
 Example `Item`::
 
@@ -238,7 +238,7 @@ Example `Item`::
         category_name=None,
         collection_code=None,
         collection_min_age_limit=None,
-        not_on_loan=False,
+        available=False,
     )
 
     """
@@ -258,7 +258,7 @@ Example `Item`::
     category_name: Optional[str]
     collection_code: Optional[str]
     collection_min_age_limit: Optional[str]
-    not_on_loan: bool
+    available: bool
 
 
 @dataclass

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -239,7 +239,7 @@ class TestGetAvailabilityInfoResponseFactory:
                     category_name=None,
                     collection_code=None,
                     collection_min_age_limit=None,
-                    not_on_loan=True
+                    available=True
                 ),
                 Item(
                     item_no='B33315118C',
@@ -258,7 +258,7 @@ class TestGetAvailabilityInfoResponseFactory:
                     category_name=None,
                     collection_code=None,
                     collection_min_age_limit=None,
-                    not_on_loan=False
+                    available=False
                 )
             ]))
         assert actual == expected

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -238,7 +238,8 @@ class TestGetAvailabilityInfoResponseFactory:
                     cluster_name=None,
                     category_name=None,
                     collection_code=None,
-                    collection_min_age_limit=None
+                    collection_min_age_limit=None,
+                    not_on_loan=True
                 ),
                 Item(
                     item_no='B33315118C',
@@ -256,7 +257,8 @@ class TestGetAvailabilityInfoResponseFactory:
                     cluster_name=None,
                     category_name=None,
                     collection_code=None,
-                    collection_min_age_limit=None
+                    collection_min_age_limit=None,
+                    not_on_loan=False
                 )
             ]))
         assert actual == expected


### PR DESCRIPTION
Instead of querying
``` 
item.status_desc == "Not On Loan"
```

Added a boolean value just to check if the status desc is not on loan. This minimizes spelling errors for users and could be a value that is more obviously important for users. 

Not on loan will be to False for "In Transit" or "On Loan" status descriptions and only True in the case of "Not On Loan"

:) 